### PR TITLE
Setup CI for BaseMigrate Frontend App

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -1,0 +1,72 @@
+name: Frontend Build CI
+
+on:
+  push:
+    branches: [ master ]
+
+  pull_request:
+    branches: [ master ]
+
+jobs:
+    build:
+      runs-on: ubuntu-latest
+
+      env:
+        NEXT_PUBLIC_PROJECT_ID: ${{ secrets.WALLET_CONNECT_ID }}
+
+      strategy:
+        matrix:
+          node-version: [ 18.x, 20.x ]
+
+      steps:
+        - uses: actions/checkout@v4
+
+        - name: Cache turbo build setup
+          uses: actions/cache@v4
+          with:
+            path: .turbo
+            key: ${{ runner.os }}-turbo-${{ github.sha }}
+            restore-keys: |
+              ${{ runner.os }}-turbo-
+
+        - name: Use Node.js ${{ matrix.node-version }}
+          uses: actions/setup-node@v4
+          with:
+            node-version: ${{ matrix.node-version }}
+            cache: "yarn"
+
+        - name: Install Dependencies
+          run: yarn install --frozen-lockfile
+
+        - name: Run Build
+          run: yarn turbo run build --filter="@base-migrate/base-migrate-app" --cache-dir=.turbo
+
+    lint:
+      runs-on: ubuntu-latest
+
+      strategy:
+        matrix:
+          node-version: [ 18.x, 20.x ]
+
+      steps:
+        - uses: actions/checkout@v4
+
+        - name: Cache turbo build setup
+          uses: actions/cache@v4
+          with:
+            path: .turbo
+            key: ${{ runner.os }}-turbo-${{ github.sha }}
+            restore-keys: |
+              ${{ runner.os }}-turbo-
+
+        - name: Use Node.js ${{ matrix.node-version }}
+          uses: actions/setup-node@v4
+          with:
+            node-version: ${{ matrix.node-version }}
+            cache: "yarn"
+
+        - name: Install Dependencies
+          run: yarn install --frozen-lockfile
+
+        - name: Run Lint
+          run: yarn turbo run lint --filter="@base-migrate/base-migrate-app" --cache-dir=.turbo


### PR DESCRIPTION
# Description
Setup the Frontend CI for `build` and `lint` commands.

**Note**: For the `build` script to pass a Github secret will need to be provided. I added one to the Github Secrets in my fork. If the build fails, you can do the same but set the key of the secret to `WALLET_CONNECT_ID` and the value should be the `NEXT_PUBLIC_PROJECT_ID` from the .env file

# Issues
Fixes #4 

## Release Note Draft Snippet
Setup CI for BaseMigrate Frontend App